### PR TITLE
Fix weird issue with the shader file paths

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -129,24 +129,24 @@ int gloLoad(char *pth)
 
 		/* Load a shader */
 		else if(strcmp(opt, "shd") == 0) {
-			char key[5], vec_pth[256], frg_pth[256];
+			char key[5], vert_pth[256], frag_pth[256], new_vert[256], new_frag[256];
 
-			/* Read the name of the model */
+			/* Read the name of the shader */
 			fscanf(fd, "%s", key);
 			printf("[%s] : ", key);
 
-			/* Read the path to the obj-file */
-			fscanf(fd, "%s", vec_pth);
-			printf("%s - ", vec_pth);
-			XSDL_CombinePath(vec_pth, dir, vec_pth);
+			/* Read the path to the vertex shader file */
+			fscanf(fd, "%s", vert_pth);
+			printf("%s - ", vert_pth);
+			XSDL_CombinePath(new_vert, dir, vert_pth);
 
-			/* Read the path to the tex-file */
-			fscanf(fd, "%s", frg_pth);
-			printf("%s ", frg_pth);
-			XSDL_CombinePath(frg_pth, dir, frg_pth);
+			/* Read the path to the fragment shader file */
+			fscanf(fd, "%s", frag_pth);
+			printf("%s ", frag_pth);
+			XSDL_CombinePath(new_frag, dir, frag_pth);
 
-			/* Load the shader from the file */
-			if(shdSet(key, vec_pth, frg_pth) < 0) {
+			/* Load the shader from the files */
+			if(shdSet(key, new_vert, new_frag) < 0) {
 				return(-1);
 			}
 		}
@@ -165,11 +165,11 @@ int gloLoad(char *pth)
 			printf("%s - ", tmp);
 			XSDL_CombinePath(obj_pth, dir, tmp);
 
-			/* Read the path to the tex-file */
+			/* Read the name of the texture */
 			fscanf(fd, "%s", tex);
 			printf("%s - ", tex);
 
-			/* Read the path to the tex-file */
+			/* Read the name of the shader */
 			fscanf(fd, "%s", shd);
 			printf("%s", shd);
 


### PR DESCRIPTION
When loading the shader files, the program has calculated this path of the vertex shader:
```
path_to_vasall-client/res//path_to_vasall-client/res//
```
The problem got fixed when i created an empty buffer for the file path.  
I also improved some comments